### PR TITLE
Fix the regius submodule location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/regius"]
 	path = vendor/regius
-	url = https://dev.pztrn.name/regius/regius.git
+	url = https://github.com/pztrn/regius.git


### PR DESCRIPTION
Repo under https://dev.pztrn.name/regius/regius.git/ doesn't exist anymore.